### PR TITLE
Add this.web3 to receive injected web3 from MetaMask

### DIFF
--- a/src/utils/getWeb3.js
+++ b/src/utils/getWeb3.js
@@ -7,9 +7,9 @@ let getWeb3 = new Promise(function(resolve, reject) {
     var web3
 
     // Checking if Web3 has been injected by the browser (Mist/MetaMask)
-    if (typeof web3 !== 'undefined') {
+    if (typeof this.web3 !== 'undefined') {
       // Use Mist/MetaMask's provider.
-      web3 = new Web3(web3.currentProvider)
+      web3 = new Web3(this.web3.currentProvider)
 
       results = {
         web3: web3


### PR DESCRIPTION
In order to access the right web3 object in the window.addEventListener there need to be a this. added to the web3 variable. Otherwise it will not be working with MetaMask.